### PR TITLE
Eg/bugfix2

### DIFF
--- a/00-create-cluster/create-gke-cluster.sh
+++ b/00-create-cluster/create-gke-cluster.sh
@@ -17,7 +17,7 @@ gcloud beta container --project "kubernetes201" clusters create "cluster-1" \
   --no-enable-basic-auth \
   --num-nodes "1" \
   --preemptible \
-  --region "us-central1" \
+  --zone "us-central1-a" \
   --scopes "https://www.googleapis.com/auth/compute","https://www.googleapis.com/auth/devstorage.read_only","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" \
   --subnetwork "default" \
 

--- a/00-create-cluster/create-gke-cluster.sh
+++ b/00-create-cluster/create-gke-cluster.sh
@@ -4,7 +4,7 @@ gcloud beta container --project "kubernetes201" clusters create "cluster-1" \
   --addons HorizontalPodAutoscaling,KubernetesDashboard \
   --cluster-version "1.9.7-gke.0" \
   --disk-size "100" \
-  --enable-autorepair
+  --enable-autorepair \
   --enable-autoscaling \
   --enable-cloud-logging \
   --enable-cloud-monitoring \


### PR DESCRIPTION
Fixing: `ERROR: (gcloud.beta.container.clusters.create) ResponseError: code=400, message=v1 API cannot be used to access GKE regional clusters. See https://goo.gl/uHKp3k for more information.`

Change reference from region to zone.

from:
--region "us-central1"
to:
--zone "us-central1-a"